### PR TITLE
Fix resize handler for PageHeader

### DIFF
--- a/src/components/Layout/PageHeader/PageHeader.vue
+++ b/src/components/Layout/PageHeader/PageHeader.vue
@@ -7,16 +7,16 @@ const isMobile = ref(window.innerWidth < 768);
 
 const isOpen = ref(false);
 
+const resizeHandler = () => {
+	isMobile.value = window.innerWidth < 768;
+};
+
 onMounted(() => {
-	window.addEventListener("resize", () => {
-		isMobile.value = window.innerWidth < 768;
-	});
+	window.addEventListener("resize", resizeHandler);
 });
 
 onUnmounted(() => {
-	window.removeEventListener("resize", () => {
-		isMobile.value = window.innerWidth < 768;
-	});
+	window.removeEventListener("resize", resizeHandler);
 });
 
 async function enter(el: Element, done: () => void) {

--- a/src/components/Layout/PageHeader/PageHeader.vue
+++ b/src/components/Layout/PageHeader/PageHeader.vue
@@ -7,7 +7,7 @@ const isMobile = ref(window.innerWidth < 768);
 
 const isOpen = ref(false);
 
-const resizeHandler = () => {
+const resizeHandler = (event: Event) => {
 	isMobile.value = window.innerWidth < 768;
 };
 


### PR DESCRIPTION
## Summary
- ensure the resize event listener is removed correctly by storing a handler reference

## Testing
- `npx biome check --apply` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcdd9083883309263e6808ee5a171