### PR TITLE
Fix asset glob pattern

### DIFF
--- a/src/components/Works/WorkItem.vue
+++ b/src/components/Works/WorkItem.vue
@@ -21,7 +21,7 @@ const handleClose = () => {
 };
 const isOpen = ref(false);
 
-const Urls = import.meta.glob<string>("../../assets/*.(svg|png|gif)", {
+const Urls = import.meta.glob<string>("../../assets/*.{svg,png,gif}", {
 	eager: true,
 	import: "default",
 });


### PR DESCRIPTION
## Summary
- fix glob syntax when importing work images

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa7f83830833091a072e5dd09d8ab