### PR TITLE
Add skill proficiency

### DIFF
--- a/src/assets/data/profile.json
+++ b/src/assets/data/profile.json
@@ -31,7 +31,36 @@
 		}
 	],
 	"about": "暗号とWebとゲームが好きです。大学では、数学とコンピュータの勉強してます。研究室では、準同型暗号に関する安全性を研究しています。サークルでは、フロントエンドとゲーム制作してます。インターン先では、バックエンドエンジニアをしています。",
-	"skills": ["Go", "C#", "C++", "Javascript", "Unity", "Vue.js"],
+	"skills": [
+                {
+                        "name": "Go",
+                        "level": "advanced"
+                },
+                {
+                        "name": "C#",
+                        "level": "beginner"
+                },
+                {
+                        "name": "C++",
+                        "level": "intermediate"
+                },
+                {
+                        "name": "Javascript",
+                        "level": "intermediate"
+                },
+                {
+                        "name": "Unity",
+                        "level": "beginner"
+                },
+                {
+                        "name": "Vue.js",
+                        "level": "beginner"
+                },
+                {
+                        "name": "Next.js",
+                        "level": "beginner"
+                }
+        ],
 	"likes": ["プログラミング", "FPS(Valorant, Overwatch)", "暗号理論"],
 	"links": [
 		{

--- a/src/assets/data/profile.json
+++ b/src/assets/data/profile.json
@@ -2,14 +2,14 @@
 	"name": "tesso",
 	"id": "@tesso57",
 	"belongings": [
-		{
-			"name": "東京科学大情報理工学院 数理計算科学系",
+                {
+                        "name": "東京科学大学情報理工学院 数理計算科学系",
 			"link": "https://educ.titech.ac.jp/is/",
 			"since": "2020-4-1",
 			"until": "2024-3-31"
 		},
-		{
-			"name": "東京科学大情報理工学院 数理計算科学系 修士課程",
+                {
+                        "name": "東京科学大学情報理工学院 数理計算科学系 修士課程",
 			"link": "https://educ.titech.ac.jp/is/",
 			"since": "2024-4-1"
 		},
@@ -19,8 +19,8 @@
 			"since": "2020-10-1",
 			"until": "2024-3-31"
 		},
-		{
-			"name": "東京科学大デジタル同好会traP",
+                {
+                        "name": "東京科学大学デジタル同好会traP",
 			"link": "https://trap.jp",
 			"since": "2020-5-12"
 		},

--- a/src/assets/data/profile.json
+++ b/src/assets/data/profile.json
@@ -54,7 +54,7 @@
                 },
                 {
                         "name": "Vue.js",
-                        "level": "beginner"
+                        "level": "intermediate"
                 },
                 {
                         "name": "Next.js",

--- a/src/assets/data/profile.json
+++ b/src/assets/data/profile.json
@@ -3,13 +3,13 @@
 	"id": "@tesso57",
 	"belongings": [
 		{
-			"name": "東京工業大学情報理工学院 数理計算科学系",
+			"name": "東京科学大情報理工学院 数理計算科学系",
 			"link": "https://educ.titech.ac.jp/is/",
 			"since": "2020-4-1",
 			"until": "2024-3-31"
 		},
 		{
-			"name": "東京工業大学情報理工学院 数理計算科学系 修士課程",
+			"name": "東京科学大情報理工学院 数理計算科学系 修士課程",
 			"link": "https://educ.titech.ac.jp/is/",
 			"since": "2024-4-1"
 		},
@@ -20,7 +20,7 @@
 			"until": "2024-3-31"
 		},
 		{
-			"name": "東京工業大学デジタル同好会traP",
+			"name": "東京科学大デジタル同好会traP",
 			"link": "https://trap.jp",
 			"since": "2020-5-12"
 		},

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -15,7 +15,6 @@ const props = defineProps({
 const styled = computed(() => ({
         height: `${props.size}px`,
         width: `${props.size}px`,
-        color: 'inherit',
 }));
 </script>
 

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -13,8 +13,9 @@ const props = defineProps({
 });
 
 const styled = computed(() => ({
-	height: `${props.size}px`,
-	width: `${props.size}px`,
+        height: `${props.size}px`,
+        width: `${props.size}px`,
+        color: 'inherit',
 }));
 </script>
 
@@ -30,7 +31,8 @@ const styled = computed(() => ({
 }
 
 .container {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  color: inherit;
 }
 </style>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -125,6 +125,6 @@ const starCount = (level: string): number => {
 }
 
 .faded {
-  color: lighten($color-highlight, 40%);
+  color: color.adjust($color-highlight, $lightness: 40%);
 }
 </style>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -2,11 +2,11 @@
 import Profile from "@/assets/data/profile.json";
 import Link from "@/components/Profile/Link.vue";
 import { format } from "@/lib/date";
+import { computed } from "vue";
 import PageContainer from "../components/Layout/PageContainer.vue";
 import SectionContainer from "../components/Layout/SectionContainer.vue";
 import ExternalLink from "../components/UI/ExternalLink.vue";
 import Icon from "../components/UI/Icon.vue";
-import { computed } from "vue";
 
 const starCount = (level: string): number => {
   switch (level) {
@@ -21,14 +21,16 @@ const starCount = (level: string): number => {
   }
 };
 
-const levelRank = {
+const levelRank: Record<string, number> = {
   advanced: 3,
   intermediate: 2,
   beginner: 1,
 };
 
 const sortedSkills = computed(() =>
-  [...Profile.skills].sort((a, b) => levelRank[b.level] - levelRank[a.level])
+  [...(Profile.skills as { name: string; level: string }[])].sort(
+    (a, b) => (levelRank[b.level] ?? 0) - (levelRank[a.level] ?? 0)
+  )
 );
 </script>
 

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -91,6 +91,7 @@ const starCount = (level: string): number => {
 </template>
 
 <style lang="scss" module>
+@use "sass:color";
 .container {
   display: flex;
   flex-direction: column;

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -5,6 +5,20 @@ import { format } from "@/lib/date";
 import PageContainer from "../components/Layout/PageContainer.vue";
 import SectionContainer from "../components/Layout/SectionContainer.vue";
 import ExternalLink from "../components/UI/ExternalLink.vue";
+import Icon from "../components/UI/Icon.vue";
+
+const starCount = (level: string): number => {
+  switch (level) {
+    case "advanced":
+      return 5;
+    case "intermediate":
+      return 3;
+    case "beginner":
+      return 1;
+    default:
+      return 0;
+  }
+};
 </script>
 
 <template>
@@ -41,7 +55,16 @@ import ExternalLink from "../components/UI/ExternalLink.vue";
         <template v-slot:header>
           <h2>Skills</h2>
         </template>
-        <p v-for="(skill, id) in Profile.skills" :key="id">{{ skill }}</p>
+        <p v-for="(skill, id) in Profile.skills" :key="id">
+          {{ skill.name }}
+          <Icon
+            v-for="n in 5"
+            :key="n"
+            name="mdi:star"
+            :size="16"
+            :class="[$style.star, n > starCount(skill.level) && $style.faded]"
+          />
+        </p>
       </SectionContainer>
       <SectionContainer>
         <template v-slot:header>
@@ -95,5 +118,13 @@ import ExternalLink from "../components/UI/ExternalLink.vue";
 
 .link {
   color: $color-secondary;
+}
+
+.star {
+  color: $color-highlight;
+}
+
+.faded {
+  color: lighten($color-highlight, 40%);
 }
 </style>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -126,6 +126,6 @@ const starCount = (level: string): number => {
 }
 
 .faded {
-  color: color.adjust($color-highlight, $lightness: 40%);
+  color: color.adjust($color-highlight, $lightness: 30%);
 }
 </style>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -6,6 +6,7 @@ import PageContainer from "../components/Layout/PageContainer.vue";
 import SectionContainer from "../components/Layout/SectionContainer.vue";
 import ExternalLink from "../components/UI/ExternalLink.vue";
 import Icon from "../components/UI/Icon.vue";
+import { computed } from "vue";
 
 const starCount = (level: string): number => {
   switch (level) {
@@ -19,6 +20,16 @@ const starCount = (level: string): number => {
       return 0;
   }
 };
+
+const levelRank = {
+  advanced: 3,
+  intermediate: 2,
+  beginner: 1,
+};
+
+const sortedSkills = computed(() =>
+  [...Profile.skills].sort((a, b) => levelRank[b.level] - levelRank[a.level])
+);
 </script>
 
 <template>
@@ -55,7 +66,7 @@ const starCount = (level: string): number => {
         <template v-slot:header>
           <h2>Skills</h2>
         </template>
-        <p v-for="(skill, id) in Profile.skills" :key="id">
+        <p v-for="(skill, id) in sortedSkills" :key="id">
           {{ skill.name }}
           <Icon
             v-for="n in 5"


### PR DESCRIPTION
## Summary
- show skill proficiency in the profile
- always display 5 stars and fade the rest

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419845d89c8330aa8ef111180beaf9