### PR TITLE
Store skill levels numerically

### DIFF
--- a/src/assets/data/profile.json
+++ b/src/assets/data/profile.json
@@ -39,31 +39,35 @@
 	"skills": [
                 {
                         "name": "Go",
-                        "level": "advanced"
+                        "level": 4
                 },
                 {
                         "name": "C#",
-                        "level": "beginner"
+                        "level": 1
                 },
                 {
                         "name": "C++",
-                        "level": "intermediate"
+                        "level": 3
                 },
                 {
                         "name": "Javascript",
-                        "level": "intermediate"
+                        "level": 3
                 },
                 {
                         "name": "Unity",
-                        "level": "beginner"
+                        "level": 1
                 },
                 {
                         "name": "Vue.js",
-                        "level": "intermediate"
+                        "level": 1
                 },
                 {
                         "name": "Next.js",
-                        "level": "beginner"
+                        "level": 2
+                },
+                {
+                        "name": "AWS",
+                        "level": 1
                 }
         ],
 	"likes": ["プログラミング", "FPS(Valorant, Overwatch)", "暗号理論"],

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -8,28 +8,9 @@ import SectionContainer from "../components/Layout/SectionContainer.vue";
 import ExternalLink from "../components/UI/ExternalLink.vue";
 import Icon from "../components/UI/Icon.vue";
 
-const starCount = (level: string): number => {
-	switch (level) {
-		case "advanced":
-			return 5;
-		case "intermediate":
-			return 3;
-		case "beginner":
-			return 1;
-		default:
-			return 0;
-	}
-};
-
-const levelRank: Record<string, number> = {
-	advanced: 3,
-	intermediate: 2,
-	beginner: 1,
-};
-
 const sortedSkills = computed(() =>
-	[...(Profile.skills as { name: string; level: string }[])].sort(
-		(a, b) => (levelRank[b.level] ?? 0) - (levelRank[a.level] ?? 0),
+	[...(Profile.skills as { name: string; level: number }[])].sort(
+		(a, b) => b.level - a.level,
 	),
 );
 </script>
@@ -75,7 +56,7 @@ const sortedSkills = computed(() =>
             :key="n"
             name="mdi:star"
             :size="16"
-            :class="[$style.star, n > starCount(skill.level) && $style.faded]"
+            :class="[$style.star, n > skill.level && $style.faded]"
           />
         </p>
       </SectionContainer>


### PR DESCRIPTION
## Summary
- store numeric levels in profile data
- sort skills by numeric level and show stars accordingly
- tweak skill levels

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684531708c408330bf1dbdbb8934290b