### PR TITLE
[codex] Add shared page gutter layout

### DIFF
--- a/src/components/Blog/BlogList.module.css
+++ b/src/components/Blog/BlogList.module.css
@@ -1,5 +1,5 @@
 .section {
-	padding: 72px 28px 80px;
+	padding-block: 72px 80px;
 	border-top: var(--line-width) solid var(--ink);
 	border-bottom: var(--line-width) solid var(--ink);
 	background:
@@ -43,7 +43,7 @@
 
 @media (max-width: 640px) {
 	.section {
-		padding: 48px 18px;
+		padding-block: 48px;
 	}
 
 	.list {

--- a/src/components/Blog/BlogList.tsx
+++ b/src/components/Blog/BlogList.tsx
@@ -1,3 +1,4 @@
+import { PageGutter } from "@/components/Layout/PageGutter";
 import { SectionHeading } from "@/components/Layout/SectionHeading";
 import type { Blog } from "@/lib/blog";
 import styles from "./BlogList.module.css";
@@ -10,12 +11,14 @@ type BlogListProps = {
 export function BlogList({ blogs }: BlogListProps) {
 	return (
 		<section className={styles.section} id="blog">
-			<SectionHeading eyebrow="04" title="Blog" sub="覚え書き" />
-			<div className={styles.list}>
-				{blogs.map((blog) => (
-					<BlogRow blog={blog} key={blog.slug} />
-				))}
-			</div>
+			<PageGutter>
+				<SectionHeading eyebrow="04" title="Blog" sub="覚え書き" />
+				<div className={styles.list}>
+					{blogs.map((blog) => (
+						<BlogRow blog={blog} key={blog.slug} />
+					))}
+				</div>
+			</PageGutter>
 		</section>
 	);
 }

--- a/src/components/Blog/BlogPost.module.css
+++ b/src/components/Blog/BlogPost.module.css
@@ -5,7 +5,8 @@
 
 .article {
 	max-width: 840px;
-	padding: 64px 28px 96px;
+	padding-block: 64px 96px;
+	padding-inline: var(--page-gutter);
 	margin: 0 auto;
 }
 

--- a/src/components/Layout/PageFooter.module.css
+++ b/src/components/Layout/PageFooter.module.css
@@ -1,11 +1,14 @@
 .footer {
-	display: flex;
-	justify-content: space-between;
-	gap: 12px;
-	flex-wrap: wrap;
-	padding: 18px 28px;
 	border-top: 1.5px solid var(--ink);
 	color: var(--ink-soft);
 	font-family: var(--mono);
 	font-size: var(--font-body-sm);
+}
+
+.inner {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+	padding-block: 18px;
 }

--- a/src/components/Layout/PageFooter.tsx
+++ b/src/components/Layout/PageFooter.tsx
@@ -1,13 +1,16 @@
+import { PageGutter } from "@/components/Layout/PageGutter";
 import { LiveClock } from "@/components/UI/LiveClock";
 import styles from "./PageFooter.module.css";
 
 export function PageFooter() {
 	return (
 		<footer className={styles.footer}>
-			<span>© 2026 tesso.dev</span>
-			<span>
-				東京 / Tokyo · <LiveClock />
-			</span>
+			<PageGutter className={styles.inner}>
+				<span>© 2026 tesso.dev</span>
+				<span>
+					東京 / Tokyo · <LiveClock />
+				</span>
+			</PageGutter>
 		</footer>
 	);
 }

--- a/src/components/Layout/PageGutter.module.css
+++ b/src/components/Layout/PageGutter.module.css
@@ -1,0 +1,3 @@
+.gutter {
+	padding-inline: var(--page-gutter);
+}

--- a/src/components/Layout/PageGutter.tsx
+++ b/src/components/Layout/PageGutter.tsx
@@ -1,0 +1,16 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import styles from "./PageGutter.module.css";
+
+type PageGutterProps = HTMLAttributes<HTMLDivElement>;
+
+export const PageGutter = forwardRef<HTMLDivElement, PageGutterProps>(
+	({ className, ...props }, ref) => (
+		<div
+			className={className ? `${styles.gutter} ${className}` : styles.gutter}
+			ref={ref}
+			{...props}
+		/>
+	),
+);
+
+PageGutter.displayName = "PageGutter";

--- a/src/components/Layout/SiteNav.module.css
+++ b/src/components/Layout/SiteNav.module.css
@@ -2,14 +2,17 @@
 	position: sticky;
 	top: 0;
 	z-index: 40;
+	border-bottom: var(--line-width) solid var(--ink);
+	background: color-mix(in srgb, var(--bg) 88%, transparent);
+	backdrop-filter: blur(8px);
+}
+
+.inner {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 16px;
-	padding: 16px 28px;
-	border-bottom: var(--line-width) solid var(--ink);
-	background: color-mix(in srgb, var(--bg) 88%, transparent);
-	backdrop-filter: blur(8px);
+	padding-block: 16px;
 	min-height: var(--site-header-height);
 }
 
@@ -82,11 +85,11 @@
 }
 
 @media (max-width: 760px) {
-	.header {
+	.inner {
 		flex-direction: column;
 		align-items: flex-start;
 		gap: 10px;
-		padding: 14px 18px;
+		padding-block: 14px;
 	}
 
 	.nav {

--- a/src/components/Layout/SiteNav.tsx
+++ b/src/components/Layout/SiteNav.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router";
+import { PageGutter } from "./PageGutter";
 import styles from "./SiteNav.module.css";
 
 const links = [
@@ -12,20 +13,22 @@ const links = [
 export function SiteNav() {
 	return (
 		<header className={styles.header}>
-			<Link className={styles.brand} to="/">
-				<span className={styles.mark}>t</span>
-				<span className={styles.name}>
-					<span className={styles.nameBase}>tesso</span>
-					<span className={styles.nameSuffix}>.dev</span>
-				</span>
-			</Link>
-			<nav className={styles.nav} aria-label="Primary">
-				{links.map((link) => (
-					<a className={styles.link} href={link.href} key={link.href}>
-						{link.label}
-					</a>
-				))}
-			</nav>
+			<PageGutter className={styles.inner}>
+				<Link className={styles.brand} to="/">
+					<span className={styles.mark}>t</span>
+					<span className={styles.name}>
+						<span className={styles.nameBase}>tesso</span>
+						<span className={styles.nameSuffix}>.dev</span>
+					</span>
+				</Link>
+				<nav className={styles.nav} aria-label="Primary">
+					{links.map((link) => (
+						<a className={styles.link} href={link.href} key={link.href}>
+							{link.label}
+						</a>
+					))}
+				</nav>
+			</PageGutter>
 		</header>
 	);
 }

--- a/src/components/Profile/AboutSection.module.css
+++ b/src/components/Profile/AboutSection.module.css
@@ -1,5 +1,5 @@
 .section {
-	padding: 96px 28px 60px;
+	padding-block: 96px 60px;
 }
 
 .grid {
@@ -96,7 +96,7 @@
 
 @media (max-width: 860px) {
 	.section {
-		padding: 72px 22px 48px;
+		padding-block: 72px 48px;
 	}
 
 	.grid {

--- a/src/components/Profile/AboutSection.tsx
+++ b/src/components/Profile/AboutSection.tsx
@@ -1,3 +1,4 @@
+import { PageGutter } from "@/components/Layout/PageGutter";
 import { SectionHeading } from "@/components/Layout/SectionHeading";
 import { Pill } from "@/components/UI/Pill";
 import type { Profile } from "@/lib/profile";
@@ -12,40 +13,42 @@ export function AboutSection({ profile }: AboutSectionProps) {
 
 	return (
 		<section className={styles.section} id="about">
-			<div className={styles.grid}>
-				<div>
-					<SectionHeading eyebrow="01" title="About" sub="自己紹介" />
-				</div>
-				<div className={styles.content}>
-					<p className={styles.body}>{profile.about}</p>
-					<div className={styles.blocks}>
-						<div>
-							<div className={styles.label}>SKILLS / 得意なもの</div>
-							<div className={styles.skills}>
-								{sortedSkills.map((skill) => (
-									<div className={styles.skill} key={skill.name}>
-										<span className={styles.skillName}>{skill.name}</span>
-										<span className={styles.meter}>
-											<span
-												className={styles.meterFill}
-												style={{ width: `${(skill.level / 5) * 100}%` }}
-											/>
-										</span>
-									</div>
-								))}
+			<PageGutter>
+				<div className={styles.grid}>
+					<div>
+						<SectionHeading eyebrow="01" title="About" sub="自己紹介" />
+					</div>
+					<div className={styles.content}>
+						<p className={styles.body}>{profile.about}</p>
+						<div className={styles.blocks}>
+							<div>
+								<div className={styles.label}>SKILLS / 得意なもの</div>
+								<div className={styles.skills}>
+									{sortedSkills.map((skill) => (
+										<div className={styles.skill} key={skill.name}>
+											<span className={styles.skillName}>{skill.name}</span>
+											<span className={styles.meter}>
+												<span
+													className={styles.meterFill}
+													style={{ width: `${(skill.level / 5) * 100}%` }}
+												/>
+											</span>
+										</div>
+									))}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className={styles.label}>LIKES / 好きなもの</div>
-							<div className={styles.likes}>
-								{profile.likes.map((like) => (
-									<Pill key={like}>{like}</Pill>
-								))}
+							<div>
+								<div className={styles.label}>LIKES / 好きなもの</div>
+								<div className={styles.likes}>
+									{profile.likes.map((like) => (
+										<Pill key={like}>{like}</Pill>
+									))}
+								</div>
 							</div>
 						</div>
 					</div>
 				</div>
-			</div>
+			</PageGutter>
 		</section>
 	);
 }

--- a/src/components/Profile/BelongingTimeline.module.css
+++ b/src/components/Profile/BelongingTimeline.module.css
@@ -14,7 +14,6 @@
 	justify-content: space-between;
 	gap: 16px;
 	flex-wrap: wrap;
-	padding: 0 28px;
 }
 
 .titleRow {
@@ -70,7 +69,6 @@
 }
 
 .scroller {
-	padding: 0 28px;
 	margin-top: 44px;
 	overflow-x: auto;
 	overflow-y: visible;
@@ -308,7 +306,6 @@
 	justify-content: space-between;
 	gap: 8px;
 	flex-wrap: wrap;
-	padding: 0 28px;
 	margin-top: 8px;
 	color: var(--ink-soft);
 	font-family: var(--mono);

--- a/src/components/Profile/BelongingTimeline.tsx
+++ b/src/components/Profile/BelongingTimeline.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { PageGutter } from "@/components/Layout/PageGutter";
 import type { Belonging } from "@/lib/profile";
 import type { TimelineLane, TimelineLaneBar } from "@/lib/timeline";
 import { createTimelineModel, getTimelinePercent } from "@/lib/timeline";
@@ -87,7 +88,7 @@ export function BelongingTimeline({ items }: BelongingTimelineProps) {
 
 	return (
 		<section className={styles.section} id="belonging">
-			<div className={styles.header}>
+			<PageGutter className={styles.header}>
 				<div>
 					<div className={styles.titleRow}>
 						<span className={styles.number}>02</span>
@@ -106,9 +107,9 @@ export function BelongingTimeline({ items }: BelongingTimelineProps) {
 						</span>
 					))}
 				</div>
-			</div>
+			</PageGutter>
 
-			<div className={styles.scroller} ref={scrollerRef}>
+			<PageGutter className={styles.scroller} ref={scrollerRef}>
 				<div className={styles.timeline}>
 					<div className={styles.years}>
 						{years.map((year) => (
@@ -162,13 +163,13 @@ export function BelongingTimeline({ items }: BelongingTimelineProps) {
 						))}
 					</div>
 				</div>
-			</div>
-			<div className={styles.hint}>
+			</PageGutter>
+			<PageGutter className={styles.hint}>
 				<span>
 					{items.length} entries · {startYear} → now
 				</span>
 				<span>← scroll · click bar for details →</span>
-			</div>
+			</PageGutter>
 		</section>
 	);
 }

--- a/src/components/Profile/Hero.module.css
+++ b/src/components/Profile/Hero.module.css
@@ -1,7 +1,7 @@
 .hero {
 	position: relative;
 	overflow: hidden;
-	padding: 80px 28px 86px;
+	padding-block: 80px 86px;
 }
 
 .role {
@@ -114,15 +114,11 @@
 
 @media (max-width: 980px) {
 	.hero {
-		padding: 64px 22px 72px;
+		padding-block: 64px 72px;
 	}
 }
 
 @media (max-width: 560px) {
-	.hero {
-		padding-inline: 22px;
-	}
-
 	.title {
 		font-size: var(--font-hero-title-mobile);
 	}

--- a/src/components/Profile/Hero.tsx
+++ b/src/components/Profile/Hero.tsx
@@ -1,3 +1,4 @@
+import { PageGutter } from "@/components/Layout/PageGutter";
 import { LiveClock } from "@/components/UI/LiveClock";
 import type { Profile } from "@/lib/profile";
 import styles from "./Hero.module.css";
@@ -9,31 +10,33 @@ type HeroProps = {
 export function Hero({ profile }: HeroProps) {
 	return (
 		<section className={styles.hero}>
-			<div className={styles.role}>⌁ {profile.role}</div>
-			<h1 className={styles.title}>
-				<span>{profile.name}</span>
-				<span className={styles.titleAccent}>.dev</span>
-			</h1>
+			<PageGutter>
+				<div className={styles.role}>⌁ {profile.role}</div>
+				<h1 className={styles.title}>
+					<span>{profile.name}</span>
+					<span className={styles.titleAccent}>.dev</span>
+				</h1>
 
-			<div className={styles.grid}>
-				<aside className={styles.now} aria-label="現在地">
-					<div className={styles.nowHeader}>
-						<span className={styles.nowEyebrow}>📍 現在地 / NOW</span>
-						<span className={styles.dot} />
-					</div>
-					<ul className={styles.nowList}>
-						{profile.nowLines.map((line) => (
-							<li key={line}>{line}</li>
-						))}
-					</ul>
-					<div className={styles.clockRow}>
-						<span className={styles.clockLabel}>TOKYO</span>
-						<span className={styles.clock}>
-							<LiveClock />
-						</span>
-					</div>
-				</aside>
-			</div>
+				<div className={styles.grid}>
+					<aside className={styles.now} aria-label="現在地">
+						<div className={styles.nowHeader}>
+							<span className={styles.nowEyebrow}>📍 現在地 / NOW</span>
+							<span className={styles.dot} />
+						</div>
+						<ul className={styles.nowList}>
+							{profile.nowLines.map((line) => (
+								<li key={line}>{line}</li>
+							))}
+						</ul>
+						<div className={styles.clockRow}>
+							<span className={styles.clockLabel}>TOKYO</span>
+							<span className={styles.clock}>
+								<LiveClock />
+							</span>
+						</div>
+					</aside>
+				</div>
+			</PageGutter>
 		</section>
 	);
 }

--- a/src/components/Profile/LinksSection.module.css
+++ b/src/components/Profile/LinksSection.module.css
@@ -1,5 +1,5 @@
 .section {
-	padding: 60px 28px 80px;
+	padding-block: 60px 80px;
 }
 
 .bar {
@@ -195,7 +195,7 @@
 
 @media (max-width: 560px) {
 	.section {
-		padding: 48px 18px 64px;
+		padding-block: 48px 64px;
 	}
 
 	.count {

--- a/src/components/Profile/LinksSection.tsx
+++ b/src/components/Profile/LinksSection.tsx
@@ -3,6 +3,7 @@ import noteIcon from "@/assets/note.svg";
 import sizuIcon from "@/assets/sizu.svg";
 import speakerdeckIcon from "@/assets/speakerdeck.svg";
 import zennIcon from "@/assets/zenn.svg";
+import { PageGutter } from "@/components/Layout/PageGutter";
 import { SectionHeading } from "@/components/Layout/SectionHeading";
 import { ExternalLink } from "@/components/UI/ExternalLink";
 import { Icon, iconNameForLink } from "@/components/UI/Icon";
@@ -52,55 +53,59 @@ export function LinksSection({ links }: LinksSectionProps) {
 
 	return (
 		<section className={styles.section} id="links">
-			<SectionHeading eyebrow="05" title="Links" sub="リンク集" />
-			<div className={styles.bar}>
-				<div className={styles.chrome}>
-					<div className={styles.lights} aria-hidden="true">
-						<span className={styles.lightRed} />
-						<span className={styles.lightYellow} />
-						<span className={styles.lightGreen} />
+			<PageGutter>
+				<SectionHeading eyebrow="05" title="Links" sub="リンク集" />
+				<div className={styles.bar}>
+					<div className={styles.chrome}>
+						<div className={styles.lights} aria-hidden="true">
+							<span className={styles.lightRed} />
+							<span className={styles.lightYellow} />
+							<span className={styles.lightGreen} />
+						</div>
+						<div className={styles.address}>⌂ tesso.dev / links</div>
+						<span className={styles.count}>{links.length} ITEMS</span>
 					</div>
-					<div className={styles.address}>⌂ tesso.dev / links</div>
-					<span className={styles.count}>{links.length} ITEMS</span>
-				</div>
-				<div className={styles.folders}>
-					{folderNames.map((folder) => {
-						const isActive = activeFolder === folder;
-						return (
-							<button
-								className={`${styles.folder} ${isActive ? styles.folderActive : ""}`}
-								key={folder}
-								type="button"
-								onClick={() => setActiveFolder(folder)}
+					<div className={styles.folders}>
+						{folderNames.map((folder) => {
+							const isActive = activeFolder === folder;
+							return (
+								<button
+									className={`${styles.folder} ${isActive ? styles.folderActive : ""}`}
+									key={folder}
+									type="button"
+									onClick={() => setActiveFolder(folder)}
+								>
+									<span className={styles.folderIcon}>
+										{folderIcon(folder)}
+									</span>
+									<span>{folder}</span>
+									<span className={styles.folderCount}>
+										{grouped.get(folder)?.length ?? 0}
+									</span>
+								</button>
+							);
+						})}
+					</div>
+					<div className={styles.items}>
+						{activeLinks.map((link) => (
+							<ExternalLink
+								className={styles.item}
+								href={link.url}
+								key={link.url}
 							>
-								<span className={styles.folderIcon}>{folderIcon(folder)}</span>
-								<span>{folder}</span>
-								<span className={styles.folderCount}>
-									{grouped.get(folder)?.length ?? 0}
+								<span className={styles.itemIcon}>{linkIcon(link)}</span>
+								<span>
+									<span className={styles.itemName}>{link.name}</span>
+									<span className={styles.itemUrl}>{link.url}</span>
 								</span>
-							</button>
-						);
-					})}
+								<span className={styles.arrow}>
+									<Icon name="arrow" size={14} />
+								</span>
+							</ExternalLink>
+						))}
+					</div>
 				</div>
-				<div className={styles.items}>
-					{activeLinks.map((link) => (
-						<ExternalLink
-							className={styles.item}
-							href={link.url}
-							key={link.url}
-						>
-							<span className={styles.itemIcon}>{linkIcon(link)}</span>
-							<span>
-								<span className={styles.itemName}>{link.name}</span>
-								<span className={styles.itemUrl}>{link.url}</span>
-							</span>
-							<span className={styles.arrow}>
-								<Icon name="arrow" size={14} />
-							</span>
-						</ExternalLink>
-					))}
-				</div>
-			</div>
+			</PageGutter>
 		</section>
 	);
 }

--- a/src/components/Works/WorkList.module.css
+++ b/src/components/Works/WorkList.module.css
@@ -1,5 +1,5 @@
 .section {
-	padding: 60px 28px;
+	padding-block: 60px;
 }
 
 .header {
@@ -49,7 +49,7 @@
 
 @media (max-width: 640px) {
 	.section {
-		padding: 48px 18px;
+		padding-block: 48px;
 	}
 
 	.grid {

--- a/src/components/Works/WorkList.tsx
+++ b/src/components/Works/WorkList.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { PageGutter } from "@/components/Layout/PageGutter";
 import { SectionHeading } from "@/components/Layout/SectionHeading";
 import type { Work } from "@/lib/work";
 import { WorkCard } from "./WorkCard";
@@ -43,22 +44,24 @@ export function WorkList({ works }: WorkListProps) {
 
 	return (
 		<section className={styles.section} id="works">
-			<div className={styles.header}>
-				<SectionHeading eyebrow="03" title="Works" sub="制作物" />
-			</div>
-			<div className={styles.grid}>
-				{entries.map(({ work, imageUrl, index }) => (
-					<div className={cellClassForIndex(index)} key={work.title}>
-						<WorkCard
-							work={work}
-							imageUrl={imageUrl}
-							index={index}
-							total={works.length}
-							onOpen={() => setSelectedIndex(index)}
-						/>
-					</div>
-				))}
-			</div>
+			<PageGutter>
+				<div className={styles.header}>
+					<SectionHeading eyebrow="03" title="Works" sub="制作物" />
+				</div>
+				<div className={styles.grid}>
+					{entries.map(({ work, imageUrl, index }) => (
+						<div className={cellClassForIndex(index)} key={work.title}>
+							<WorkCard
+								work={work}
+								imageUrl={imageUrl}
+								index={index}
+								total={works.length}
+								onOpen={() => setSelectedIndex(index)}
+							/>
+						</div>
+					))}
+				</div>
+			</PageGutter>
 			{selectedWork && selectedIndex !== null ? (
 				<WorkModal
 					work={selectedWork}

--- a/src/index.css
+++ b/src/index.css
@@ -74,6 +74,9 @@
 	--font-hero-title: clamp(4rem, 13vw, 13.75rem);
 	--font-hero-title-mobile: clamp(3.75rem, 22vw, 6.5rem);
 	--line-width: 1.5px;
+	--page-gutter-block: clamp(1.5rem, 3vw, 2.5rem);
+	--page-gutter-inline: clamp(2rem, 5vw, 4rem);
+	--page-gutter: var(--page-gutter-inline);
 	--site-header-height: 70px;
 }
 
@@ -134,6 +137,7 @@ section[id] {
 
 @media (max-width: 760px) {
 	:root {
+		--page-gutter: 22px;
 		--site-header-height: 104px;
 	}
 }

--- a/src/views/NotFound.module.css
+++ b/src/views/NotFound.module.css
@@ -1,6 +1,7 @@
 .page {
 	min-height: 100vh;
-	padding: 64px 28px;
+	padding-block: 64px;
+	padding-inline: var(--page-gutter);
 	background: var(--bg);
 	color: var(--ink);
 }


### PR DESCRIPTION
## Summary
- Add a shared PageGutter layout component for common horizontal page spacing
- Move header, footer, and main home sections to use the shared gutter wrapper
- Keep section CSS focused on vertical spacing and local layout
- Update page gutter tokens to the requested clamp values

## Validation
- npm run lint
- npm run build
